### PR TITLE
Update project

### DIFF
--- a/pptx2img/App.config
+++ b/pptx2img/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/pptx2img/Program.cs
+++ b/pptx2img/Program.cs
@@ -4,7 +4,6 @@ using CommandLine;
 using CommandLine.Text;
 using Microsoft.Office.Core;
 using Microsoft.Office.Interop.PowerPoint;
-using Shape = Microsoft.Office.Interop.PowerPoint.Shape;
 
 namespace pptx2img
 {

--- a/pptx2img/packages.config
+++ b/pptx2img/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="CommandLineParser" version="1.9.71" targetFramework="net461" />
-</packages>

--- a/pptx2img/pptx2img.csproj
+++ b/pptx2img/pptx2img.csproj
@@ -8,9 +8,10 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>pptx2img</RootNamespace>
     <AssemblyName>pptx2img</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/pptx2img/pptx2img.csproj
+++ b/pptx2img/pptx2img.csproj
@@ -33,9 +33,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CommandLine, Version=1.9.71.2, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
-      <HintPath>..\packages\CommandLineParser.1.9.71\lib\net45\CommandLine.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -52,7 +49,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <COMReference Include="Microsoft.Office.Core">
@@ -82,6 +78,11 @@
       <Isolated>False</Isolated>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </COMReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser">
+      <Version>1.9.71</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/pptx2img/pptx2img.csproj
+++ b/pptx2img/pptx2img.csproj
@@ -81,7 +81,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser">
-      <Version>1.9.71</Version>
+      <Version>2.9.1</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/pptx2img/pptx2img.csproj
+++ b/pptx2img/pptx2img.csproj
@@ -81,7 +81,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser">
-      <Version>2.9.1</Version>
+      <Version>1.9.71</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
This pull request includes changes to the `pptx2img` project, including updating the target framework version, removing a library reference, and adding a new package reference. The most important changes are updating the target framework version and removing the `CommandLineParser` package.

Main project changes:

* <a href="diffhunk://#diff-53c34d223eae6064521d4b3a398035da1946d0a1770574faddaf4960f99606a0L11-R14">`pptx2img/pptx2img.csproj`</a>: Updated the target framework version, removed a library reference and the `packages.config` file, and added a new package reference for `CommandLineParser`. <a href="diffhunk://#diff-53c34d223eae6064521d4b3a398035da1946d0a1770574faddaf4960f99606a0L11-R14">[1]</a> <a href="diffhunk://#diff-53c34d223eae6064521d4b3a398035da1946d0a1770574faddaf4960f99606a0L35-L37">[2]</a> <a href="diffhunk://#diff-53c34d223eae6064521d4b3a398035da1946d0a1770574faddaf4960f99606a0L54">[3]</a> <a href="diffhunk://#diff-53c34d223eae6064521d4b3a398035da1946d0a1770574faddaf4960f99606a0R82-R86">[4]</a>

Package and dependency changes:

* <a href="diffhunk://#diff-235c3df34d28f9b2f572b80c36648ea3b7103d3bd9dcf66fd5aac026ba06a318L1-L4">`pptx2img/packages.config`</a>: Removed the `CommandLineParser` package from the `packages.config` file.

Other changes:

* <a href="diffhunk://#diff-7e56bad13402806ab9c0156038a673544fecc184bb4575d4beca12706dad95e6L7">`pptx2img/Program.cs`</a>: Removed the `using Shape = Microsoft.Office.Interop.PowerPoint.Shape;` line.
* <a href="diffhunk://#diff-24ccd386a4fbb1aebb9f982ed387e764cd1cbdf811b22dfd7b2670c55bb46b6dL1-R4">`pptx2img/App.config`</a>: Updated the project's supported runtime version from v4.6.1 to v4.8.